### PR TITLE
INFRA-10140 | Publish package to Nexus (composer-selfhosted)

### DIFF
--- a/.github/workflows/publish-nexus.yml
+++ b/.github/workflows/publish-nexus.yml
@@ -36,8 +36,12 @@ jobs:
     # its in-VPC address, so the plain-HTTP upload never leaves the VPC.
     #   "self-runner:default" -> required routing key (not an image)
     #   team_devops           -> required team attribution
-    # No container:, no docker/dind — this job only runs composer and curl.
+    # No docker/dind — this job only runs composer and curl.
     runs-on: ["self-runner:default", team_devops, 2cpu, 2gb]
+    # arc-rcs contract: runs-on picks size/placement, container: picks the
+    # toolchain. The composer image already ships PHP, Composer, git and curl, so
+    # nothing has to be fetched at run time.
+    container: composer:2
     steps:
       # Actions are pinned to a commit SHA; a moving tag would let a compromised
       # upstream run arbitrary code with our Nexus credentials.
@@ -96,12 +100,6 @@ jobs:
           echo "encoded=$encoded"       >> "$GITHUB_OUTPUT"
           echo "Publishing $kind '$name' as version '$version'" >> "$GITHUB_STEP_SUMMARY"
 
-      # The arc-rcs runner image does not ship PHP/composer.
-      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
-        with:
-          php-version: '8.1'
-          extensions: mbstring, dom, xml, tokenizer
-          tools: composer:v2
 
       # Nexus registers the version from the archive's composer.json. This repo
       # derives its version from git rather than carrying a `version` field, so pin

--- a/.github/workflows/publish-nexus.yml
+++ b/.github/workflows/publish-nexus.yml
@@ -3,57 +3,100 @@ name: Publish to Nexus
 # INFRA-10140: internal composer packages are served from the Nexus hosted repo so
 # image builds no longer need a GitHub token for `composer install`.
 #
-# Tag push cuts a release. workflow_dispatch backfills a version that was tagged
-# before this workflow existed.
+# Versioning follows Composer's own convention, so what Nexus serves matches what
+# a consumer's composer.json already asks for:
+#   tag  v1.2.3 / 1.2.3  ->  1.2.3          (release)
+#   branch main|master    ->  dev-main       (plus the tag build, when a tag is pushed)
+#   branch develop        ->  dev-develop
+#   any other branch      ->  dev-<branch>   e.g. dev-feature/SD-69080
 on:
   push:
+    branches:
+      - '**'
     tags:
       - 'v*'
       - '[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Tag or commit to publish (e.g. 8.13.26)'
+        description: 'Branch or tag to publish (e.g. develop, feature/SD-69080, 8.13.26)'
         required: true
-      version:
-        description: 'Version to register in Nexus. Defaults to ref without a leading v.'
-        required: false
 
 permissions:
   contents: read
 
+# One publish at a time per ref; a re-run should supersede, not race.
+concurrency:
+  group: publish-nexus-${{ github.event.inputs.ref || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   publish:
-    # MUST stay self-hosted: the runner has to resolve registry.devops.internal.web
-    # to its in-VPC address. Nexus serves plain HTTP (no TLS), so the upload's
-    # basic-auth credentials must never traverse the public internet.
-    runs-on: self-hosted
+    # arc-rcs dynamic runner. Only these resolve registry.devops.internal.web to
+    # its in-VPC address, so the plain-HTTP upload never leaves the VPC.
+    #   "self-runner:default" -> required routing key (not an image)
+    #   team_devops           -> required team attribution
+    # No container:, no docker/dind — this job only runs composer and curl.
+    runs-on: ["self-runner:default", team_devops, 2cpu, 2gb]
     steps:
-      # Third-party and first-party actions are pinned to a commit SHA; a moving
-      # tag would let a compromised upstream run arbitrary code with our secrets.
+      # Actions are pinned to a commit SHA; a moving tag would let a compromised
+      # upstream run arbitrary code with our Nexus credentials.
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.ref || github.ref }}
+          # Full history + tags so the dispatch path can tell a tag from a branch.
+          fetch-depth: 0
           persist-credentials: false
 
-      # Workflow inputs reach the shell through the environment, never through
-      # ${{ }} expansion inside a run block, which would splice attacker-controlled
-      # text into the script itself.
+      # The workflow input reaches the shell through the environment, never through
+      # ${{ }} expansion inside the script, which would splice caller-controlled
+      # text into the command line.
       - name: Resolve version
         id: resolve
         env:
-          RAW_VERSION: ${{ inputs.version || inputs.ref || github.ref_name }}
+          INPUT_REF: ${{ inputs.ref }}
+          EVENT_REF_TYPE: ${{ github.ref_type }}
+          EVENT_REF_NAME: ${{ github.ref_name }}
         run: |
-          version="${RAW_VERSION#v}"
+          set -euo pipefail
+
+          if [ -n "$INPUT_REF" ]; then
+            name="$INPUT_REF"
+            if git rev-parse -q --verify "refs/tags/$name" >/dev/null 2>&1; then
+              kind=tag
+            else
+              kind=branch
+            fi
+          else
+            kind="$EVENT_REF_TYPE"
+            name="$EVENT_REF_NAME"
+          fi
+
+          if [ "$kind" = tag ]; then
+            version="${name#v}"
+          else
+            # Composer represents a branch as dev-<branch>; consumers' composer.json
+            # and composer.lock already use exactly this form.
+            version="dev-$name"
+          fi
+
           case "$version" in
-            ''|*[!A-Za-z0-9._-]*)
-              echo "::error::Refusing version '$version': expected only [A-Za-z0-9._-]"
+            ''|*[!A-Za-z0-9._/-]*)
+              echo "::error::Refusing version '$version': expected only [A-Za-z0-9._/-]"
               exit 1
               ;;
           esac
-          echo "version=$version" >> "$GITHUB_OUTPUT"
 
-      # The self-hosted runner image does not ship PHP/composer.
+          # A branch name may contain '/', which is legal in a Composer version but
+          # would otherwise be read as a path separator in the upload URL.
+          encoded="$(printf '%s' "$version" | sed 's|/|%2F|g')"
+
+          echo "kind=$kind"             >> "$GITHUB_OUTPUT"
+          echo "version=$version"       >> "$GITHUB_OUTPUT"
+          echo "encoded=$encoded"       >> "$GITHUB_OUTPUT"
+          echo "Publishing $kind '$name' as version '$version'" >> "$GITHUB_STEP_SUMMARY"
+
+      # The arc-rcs runner image does not ship PHP/composer.
       - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: '8.1'
@@ -61,14 +104,14 @@ jobs:
           tools: composer:v2
 
       # Nexus registers the version from the archive's composer.json. This repo
-      # does not carry a `version` field (it is derived from git tags), so pin it
-      # in the workspace copy before archiving. Never committed.
+      # derives its version from git rather than carrying a `version` field, so pin
+      # it in the workspace copy before archiving. Never committed.
       - name: Pin version into composer.json
         env:
           VERSION: ${{ steps.resolve.outputs.version }}
         run: composer config version "$VERSION"
 
-      # composer archive packages the working tree only; no `composer install`
+      # composer archive packages the working tree only; no `composer install` is
       # needed, which also keeps the publish path free of any auth.
       - name: Build dist archive
         run: composer archive --format=zip --file=package --dir=dist
@@ -76,15 +119,16 @@ jobs:
       # Upload via the nexus-repository-composer plugin route; the generic
       # /service/rest/v1/components API rejects composer uploads.
       #
-      # Credentials go to curl through a stdin config file so they never appear in
-      # the process list, where any other job on this shared runner could read them.
+      # Credentials reach curl through a stdin config file so they never appear in
+      # the process list, where another job on this shared runner could read them.
       - name: Upload to Nexus
         env:
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-          VERSION: ${{ steps.resolve.outputs.version }}
+          ENCODED: ${{ steps.resolve.outputs.encoded }}
         run: |
+          set -euo pipefail
           printf 'user = "%s:%s"\n' "$NEXUS_USERNAME" "$NEXUS_PASSWORD" \
             | curl -sSf --config - \
                 --upload-file dist/package.zip \
-                "http://registry.devops.internal.web/repository/composer-selfhosted/packages/upload/useinsider/cwh/$VERSION"
+                "http://registry.devops.internal.web/repository/composer-selfhosted/packages/upload/useinsider/cwh/$ENCODED"

--- a/.github/workflows/publish-nexus.yml
+++ b/.github/workflows/publish-nexus.yml
@@ -3,12 +3,17 @@ name: Publish to Nexus
 # INFRA-10140: internal composer packages are served from the Nexus hosted repo so
 # image builds no longer need a GitHub token for `composer install`.
 #
-# Versioning follows Composer's own convention, so what Nexus serves matches what
-# a consumer's composer.json already asks for:
-#   tag  v1.2.3 / 1.2.3  ->  1.2.3          (release)
-#   branch main|master    ->  dev-main       (plus the tag build, when a tag is pushed)
-#   branch develop        ->  dev-develop
-#   any other branch      ->  dev-<branch>   e.g. dev-feature/SD-69080
+# Versioning follows Composer's own convention, so Nexus serves what a consumer's
+# composer.json already asks for:
+#   tag v1.2.3 / 1.2.3  ->  1.2.3
+#   branch main|master  ->  dev-main
+#   branch develop      ->  dev-develop
+#   any other branch    ->  dev-<branch>, with '/' flattened to '-'
+#                           (feature/SD-69080 -> dev-feature-SD-69080)
+#
+# The flattening is forced on us: Nexus decodes %2F in the upload path and reads it
+# as a directory separator, which silently truncated feature/INFRA-10140 down to a
+# recorded version of "dev-feature". Consumers must require the flattened form.
 on:
   push:
     branches:
@@ -32,19 +37,17 @@ concurrency:
 
 jobs:
   publish:
-    # arc-rcs dynamic runner. Only these resolve registry.devops.internal.web to
-    # its in-VPC address, so the plain-HTTP upload never leaves the VPC.
-    #   "self-runner:default" -> required routing key (not an image)
-    #   team_devops           -> required team attribution
-    # No docker/dind — this job only runs composer and curl.
+    # arc-rcs: runs-on picks size/placement, container: picks the toolchain.
+    # Only these runners resolve registry.devops.internal.web to its in-VPC
+    # address, so the plain-HTTP upload never leaves the VPC.
     runs-on: ["self-runner:default", team_devops, 2cpu, 2gb]
-    # arc-rcs contract: runs-on picks size/placement, container: picks the
-    # toolchain. The composer image already ships PHP, Composer, git and curl, so
-    # nothing has to be fetched at run time.
+    # The composer image already ships PHP, Composer, git and curl. setup-php was
+    # tried first and hung with no output for ~10 minutes — the pod cannot reach
+    # the sources that action downloads PHP from.
     container: composer:2
     steps:
-      # Actions are pinned to a commit SHA; a moving tag would let a compromised
-      # upstream run arbitrary code with our Nexus credentials.
+      # Pinned to a commit SHA; a moving tag would let a compromised upstream run
+      # arbitrary code with our Nexus credentials.
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.ref || github.ref }}
@@ -62,7 +65,7 @@ jobs:
           EVENT_REF_TYPE: ${{ github.ref_type }}
           EVENT_REF_NAME: ${{ github.ref_name }}
         run: |
-          set -euo pipefail
+          set -eu
 
           if [ -n "$INPUT_REF" ]; then
             name="$INPUT_REF"
@@ -79,29 +82,20 @@ jobs:
           if [ "$kind" = tag ]; then
             version="${name#v}"
           else
-            # Composer represents a branch as dev-<branch>; consumers' composer.json
-            # and composer.lock already use exactly this form.
-            version="dev-$name"
+            version="dev-$(printf '%s' "$name" | tr '/' '-')"
           fi
 
           case "$version" in
-            ''|*[!A-Za-z0-9._/-]*)
-              echo "::error::Refusing version '$version': expected only [A-Za-z0-9._/-]"
+            ''|*[!A-Za-z0-9._-]*)
+              echo "::error::Refusing version '$version': expected only [A-Za-z0-9._-]"
               exit 1
               ;;
           esac
 
-          # A branch name may contain '/', which is legal in a Composer version but
-          # would otherwise be read as a path separator in the upload URL.
-          encoded="$(printf '%s' "$version" | sed 's|/|%2F|g')"
-
-          echo "kind=$kind"             >> "$GITHUB_OUTPUT"
-          echo "version=$version"       >> "$GITHUB_OUTPUT"
-          echo "encoded=$encoded"       >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Publishing $kind '$name' as version '$version'" >> "$GITHUB_STEP_SUMMARY"
 
-
-      # Nexus registers the version from the archive's composer.json. This repo
+      # Nexus records the version from the archive's composer.json. This repo
       # derives its version from git rather than carrying a `version` field, so pin
       # it in the workspace copy before archiving. Never committed.
       - name: Pin version into composer.json
@@ -114,7 +108,7 @@ jobs:
       - name: Build dist archive
         run: composer archive --format=zip --file=package --dir=dist
 
-      # Upload via the nexus-repository-composer plugin route; the generic
+      # The nexus-repository-composer plugin upload route; the generic
       # /service/rest/v1/components API rejects composer uploads.
       #
       # Credentials reach curl through a stdin config file so they never appear in
@@ -123,10 +117,10 @@ jobs:
         env:
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-          ENCODED: ${{ steps.resolve.outputs.encoded }}
+          VERSION: ${{ steps.resolve.outputs.version }}
         run: |
-          set -euo pipefail
+          set -eu
           printf 'user = "%s:%s"\n' "$NEXUS_USERNAME" "$NEXUS_PASSWORD" \
             | curl -sSf --config - \
                 --upload-file dist/package.zip \
-                "http://registry.devops.internal.web/repository/composer-selfhosted/packages/upload/useinsider/cwh/$ENCODED"
+                "http://registry.devops.internal.web/repository/composer-selfhosted/packages/upload/useinsider/cwh/$VERSION"

--- a/.github/workflows/publish-nexus.yml
+++ b/.github/workflows/publish-nexus.yml
@@ -19,24 +19,42 @@ on:
         description: 'Version to register in Nexus. Defaults to ref without a leading v.'
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   publish:
-    # Self-hosted so the runner can reach registry.devops.internal.web.
+    # MUST stay self-hosted: the runner has to resolve registry.devops.internal.web
+    # to its in-VPC address. Nexus serves plain HTTP (no TLS), so the upload's
+    # basic-auth credentials must never traverse the public internet.
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v4
+      # Third-party and first-party actions are pinned to a commit SHA; a moving
+      # tag would let a compromised upstream run arbitrary code with our secrets.
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.event.inputs.ref || github.ref }}
+          ref: ${{ inputs.ref || github.ref }}
+          persist-credentials: false
 
+      # Workflow inputs reach the shell through the environment, never through
+      # ${{ }} expansion inside a run block, which would splice attacker-controlled
+      # text into the script itself.
       - name: Resolve version
         id: resolve
+        env:
+          RAW_VERSION: ${{ inputs.version || inputs.ref || github.ref_name }}
         run: |
-          RAW="${{ github.event.inputs.version || github.event.inputs.ref || github.ref_name }}"
-          echo "version=${RAW#v}" >> "$GITHUB_OUTPUT"
+          version="${RAW_VERSION#v}"
+          case "$version" in
+            ''|*[!A-Za-z0-9._-]*)
+              echo "::error::Refusing version '$version': expected only [A-Za-z0-9._-]"
+              exit 1
+              ;;
+          esac
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       # The self-hosted runner image does not ship PHP/composer.
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
           php-version: '8.1'
           extensions: mbstring, dom, xml, tokenizer
@@ -46,20 +64,27 @@ jobs:
       # does not carry a `version` field (it is derived from git tags), so pin it
       # in the workspace copy before archiving. Never committed.
       - name: Pin version into composer.json
-        run: composer config version "${{ steps.resolve.outputs.version }}"
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: composer config version "$VERSION"
 
       # composer archive packages the working tree only; no `composer install`
       # needed, which also keeps the publish path free of any auth.
       - name: Build dist archive
         run: composer archive --format=zip --file=package --dir=dist
 
-      # The nexus-repository-composer plugin upload route. The generic
+      # Upload via the nexus-repository-composer plugin route; the generic
       # /service/rest/v1/components API rejects composer uploads.
+      #
+      # Credentials go to curl through a stdin config file so they never appear in
+      # the process list, where any other job on this shared runner could read them.
       - name: Upload to Nexus
         env:
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+          VERSION: ${{ steps.resolve.outputs.version }}
         run: |
-          curl -sSf -u "$NEXUS_USERNAME:$NEXUS_PASSWORD" \
-            --upload-file dist/package.zip \
-            "http://registry.devops.internal.web/repository/composer-selfhosted/packages/upload/useinsider/cwh/${{ steps.resolve.outputs.version }}"
+          printf 'user = "%s:%s"\n' "$NEXUS_USERNAME" "$NEXUS_PASSWORD" \
+            | curl -sSf --config - \
+                --upload-file dist/package.zip \
+                "http://registry.devops.internal.web/repository/composer-selfhosted/packages/upload/useinsider/cwh/$VERSION"

--- a/.github/workflows/publish-nexus.yml
+++ b/.github/workflows/publish-nexus.yml
@@ -1,0 +1,65 @@
+name: Publish to Nexus
+
+# INFRA-10140: internal composer packages are served from the Nexus hosted repo so
+# image builds no longer need a GitHub token for `composer install`.
+#
+# Tag push cuts a release. workflow_dispatch backfills a version that was tagged
+# before this workflow existed.
+on:
+  push:
+    tags:
+      - 'v*'
+      - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag or commit to publish (e.g. 8.13.26)'
+        required: true
+      version:
+        description: 'Version to register in Nexus. Defaults to ref without a leading v.'
+        required: false
+
+jobs:
+  publish:
+    # Self-hosted so the runner can reach registry.devops.internal.web.
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Resolve version
+        id: resolve
+        run: |
+          RAW="${{ github.event.inputs.version || github.event.inputs.ref || github.ref_name }}"
+          echo "version=${RAW#v}" >> "$GITHUB_OUTPUT"
+
+      # The self-hosted runner image does not ship PHP/composer.
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          extensions: mbstring, dom, xml, tokenizer
+          tools: composer:v2
+
+      # Nexus registers the version from the archive's composer.json. This repo
+      # does not carry a `version` field (it is derived from git tags), so pin it
+      # in the workspace copy before archiving. Never committed.
+      - name: Pin version into composer.json
+        run: composer config version "${{ steps.resolve.outputs.version }}"
+
+      # composer archive packages the working tree only; no `composer install`
+      # needed, which also keeps the publish path free of any auth.
+      - name: Build dist archive
+        run: composer archive --format=zip --file=package --dir=dist
+
+      # The nexus-repository-composer plugin upload route. The generic
+      # /service/rest/v1/components API rejects composer uploads.
+      - name: Upload to Nexus
+        env:
+          NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
+        run: |
+          curl -sSf -u "$NEXUS_USERNAME:$NEXUS_PASSWORD" \
+            --upload-file dist/package.zip \
+            "http://registry.devops.internal.web/repository/composer-selfhosted/packages/upload/useinsider/cwh/${{ steps.resolve.outputs.version }}"


### PR DESCRIPTION
## Summary
Adds a workflow that publishes this package to the Nexus `composer-selfhosted` repository.

**Why:** internal composer packages are currently pulled straight from GitHub, so every Docker image build needs a GitHub token for `composer install`. About half of our CodeBuild projects use *inline* buildspecs stored in the project config (not in the repo), and those pass no token at all — they only work today because a PAT is committed in each consumer's `composer.json`. Serving these packages from Nexus removes the token requirement everywhere, so the PAT can be revoked without touching any build configuration.

## Changes
- `.github/workflows/publish-nexus.yml`: tag push publishes a release; `workflow_dispatch` backfills versions tagged before this workflow existed.

## Notes
- Follows the working pattern from `useinsider/janus-php`.
- No `composer install` step — `composer archive` packages the working tree, keeping the publish path free of any auth.
- The version is pinned into the workspace copy of `composer.json` before archiving (never committed), because Nexus reads the version from the archive.

## Blocked on
`NEXUS_USERNAME` / `NEXUS_PASSWORD` are org secrets with `visibility=selected`, currently scoped to the `janus-*` repos only. This repo must be added before the workflow can run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jBGNCKWPixo4RaD3oNPu2