### PR TITLE
MES-25178 | Coveralls → Coverus migration for remaining Vikings repos

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -5,13 +5,16 @@ on: [push, pull_request]
 jobs:
   run:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       matrix:
         php-versions: ['8.1']
     name: PHP ${{ matrix.php-versions }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -25,10 +28,10 @@ jobs:
 
       - name: Get Composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -44,10 +47,51 @@ jobs:
 
       - name: Run tests
         run: vendor/bin/phpunit --coverage-clover build/logs/clover.xml
-          
-      - name: Upload coverage results to Coveralls
+
+      # useinsider/coverus-action is NOT usable here: it lives in an internal
+      # repository, and GitHub refuses to resolve internal actions from a public
+      # one ("Unable to resolve action ..., not found"). This reimplements the
+      # same wire contract inline. Skipped on pull_request because a fork PR
+      # gets no OIDC token, and the head commit is covered by its push event.
+      - name: Upload to Coverus
+        if: github.event_name == 'push'
         env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERUS_API_URL: https://kube-qa-dataforce.useinsider.com/coverus/api
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          WORKSPACE_PREFIX: ${{ github.workspace }}/
         run: |
-          composer global require php-coveralls/php-coveralls
-          php-coveralls --coverage_clover=build/logs/clover.xml -v
+          set -eo pipefail
+
+          # Coverus indexes files by repo-relative path; phpunit writes absolute ones.
+          sed -e "s|name=\"${WORKSPACE_PREFIX}|name=\"|g" \
+              -e "s|path=\"${WORKSPACE_PREFIX}|path=\"|g" \
+              build/logs/clover.xml | gzip -9 | base64 -w 0 > coverage_encoded.txt
+
+          OIDC_TOKEN=$(curl -sS --retry 3 --retry-all-errors --retry-delay 2 \
+            --connect-timeout 10 --max-time 30 \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=coverus" | jq -r '.value // empty')
+          if [ -z "$OIDC_TOKEN" ]; then
+            echo "::error::could not obtain a GitHub OIDC token for Coverus"
+            exit 1
+          fi
+          echo "::add-mask::$OIDC_TOKEN"
+
+          jq -n --arg branch "$DEFAULT_BRANCH" --arg token "$OIDC_TOKEN" \
+                --rawfile data coverage_encoded.txt \
+            '{coverage_format:"clover", compression:"gzip", default_branch:$branch,
+              github_actions_oidc_token:$token, raw_coverage_data:($data|rtrimstr("\n"))}' \
+            > payload.json
+
+          # No --retry-all-errors: the POST is not idempotent, so a lost response
+          # must not be replayed into a duplicate job.
+          HTTP=$(curl -sS -o response.json -w '%{http_code}' -X POST \
+            --retry 3 --retry-delay 2 --connect-timeout 10 --max-time 120 \
+            -H 'Content-Type: application/json' --data-binary @payload.json \
+            "${COVERUS_API_URL}/v1/jobs/by-github-actions-oidc-token")
+
+          if [ "$HTTP" != "200" ]; then
+            echo "::error::Coverus upload failed (HTTP $HTTP): $(cat response.json)"
+            exit 1
+          fi
+          echo "Coverus job $(jq -r '.job_id' response.json) — coverage $(jq -r '.coverage' response.json)%"


### PR DESCRIPTION
## What

Coveralls is being decommissioned org-wide; coverage must go to Coverus. A DataForce audit flagged this repo as **NOT MIGRATED** (last Coveralls build 2026-04-06).

Jira: [MES-25178](https://winsider.atlassian.net/browse/MES-25178)
Guide: [Upload Coverage from GitHub Actions](https://insider-portal.atlassian.net/wiki/spaces/DataForce/pages/5502042149/Upload+Coverage+from+GitHub+Actions)

## Why this repo can't just use `useinsider/coverus-action`

It can't be resolved from here. `useinsider/coverus-action` is an **internal** repository and `useinsider/cwh` is **public**; GitHub does not allow a public repository's workflow to resolve an internal action, and the run dies before the first step:

```
##[error]Unable to resolve action `useinsider/coverus-action`, not found
```

So the upload is inlined instead, reproducing the action's wire contract exactly: strip the workspace prefix from the clover paths, `gzip -9 | base64`, exchange an `audience=coverus` GitHub OIDC token, and `POST /v1/jobs/by-github-actions-oidc-token` with `compression: gzip`. The endpoint is the action's own default (`https://kube-qa-dataforce.useinsider.com/coverus/api`), which is served publicly through Cloudflare and therefore reachable from a GitHub-hosted runner. The step uses `jq`, which is present on `ubuntu-latest`. The reason for the inlining is recorded in a comment on the step so it doesn't get "cleaned up" back to the action later.

Sister repos in this task (`ucs2-to-gsm7`, `unsubscribe-api`) are private and keep using `useinsider/coverus-action` normally.

## Other changes to `.github/workflows/php.yml`

- **`permissions: id-token: write`** — required for the OIDC exchange. `contents: read` covers the rest of the job.
- **`if: github.event_name == 'push'`** on the upload. This repo is public and a fork: fork `pull_request` runs get no OIDC token, so the step would fail the check for no reason, and a PR head commit is already covered by its own push event.
- **`actions/cache@v1` → `v4`.** Unrelated to Coverus but required: GitHub auto-fails any run using `actions/cache: v1`, which is why every `Pipeline` run since 2026-07-22 was red before a single step executed. Without this the migrated workflow could never go green.
- **`actions/checkout@v1` → `v5`** and `::set-output` → `$GITHUB_OUTPUT`, deprecated alongside the cache action.

## Verification

The transform pipeline (prefix strip → gzip → base64 → JSON body) was exercised locally against a sample clover file: absolute `name=`/`path=` attributes become repo-relative, the blob round-trips through `base64 -d | gunzip`, and the assembled payload is valid single-line JSON.

`composer install` could not be run locally (the sandbox gets HTTP 504 from `api.github.com` on dist zipballs), so the test steps are unchanged and unverified locally — they were green on 2026-04-06, the last run before the `actions/cache@v1` auto-fail. CI on this PR is the first end-to-end verification of the upload.


[MES-25178]: https://winsider.atlassian.net/browse/MES-25178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ